### PR TITLE
Change Proposal

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -114,9 +114,14 @@ function getObjectiveScore(gpa, ap5, ap4, sat) {
     output += sat / (sat_coeff / (sat / 1600));
     var gpa_coeff = 0.2;
     if (gpa < college.GPA) gpa_coeff = 0.25;
-    output += gpa / (gpa_coeff / (gpa / 4));
+    output += gpa / (gpa_coeff / (gpa ./ 4));
+    if (output > 0) var scaledObjectiveAdd = (output/50);
+    output +=  (scaledObjectiveAdd/.1); 
     var aps = parseFloat(ap5) + ap4 / 2;
-    return Math.round(100 * (output + aps)) / 100;
+    if (aps > 10) aps = 10; 
+    var objectiveScoreFinal = output + aps; 
+     
+    return Math.round(100 * (objectiveScoreFinal)) / 100;
 }
 
 getdata.onclick = function () {
@@ -156,6 +161,7 @@ getdata.onclick = function () {
 function getTotalApplicantScore(TA) {
     var index = ids.indexOf(cinput.value);
     var acceptance = actual_JSON[index].ADMISSION.replace("%", "") / 100;
+    if (TA >= 120) TA = 119.9; 
     var final = 120 - TA;
     final /= acceptance;
     final /= TA;


### PR DESCRIPTION
In the objective score method, I set it so that the max ap points you can get is 10. My reasoning is college’s probably don’t care that much whether you took 12 or 15 APs and the way we had it previously was giving too much weight to the AP scores. I also added a little scaling variable to make sure the objective section still had a maximum of 60 points. 
In the final chances method, I fixed the bug where it was generating negative results by setting if TA is greater than or equal to 120 it sets to 119.9. 
I haven’t touched the subjective method yet, but I think I’ll take a stab at that tomorrow. I think I’m gonna try to make it so it’s out of 40 points (We should shoot for the composite being out of 100 to be user friendly), so that it gives slightly more weight to the objective since that’s what we can measure best currently. I’m also going to work on making the algorithm for final chances less arbitrary and more scientific/accurate. My initial thoughts are using the stored avg gpa and test scores for each school to generate an average objective score for each school and then base how it weighs your objective and subjective information and calculates chances based on that. I think that might simulate how college admissions officer actually act. Anyways, I’ll take a look at that tomorrow.